### PR TITLE
Configure root_url in granafa.ini

### DIFF
--- a/roles/matrix-grafana/templates/grafana.ini.j2
+++ b/roles/matrix-grafana/templates/grafana.ini.j2
@@ -1,3 +1,6 @@
+[server]
+root_url = "https://{{ matrix_server_fqn_grafana }}"
+
 [security]
 # default admin user, created on startup
 admin_user = "{{ matrix_grafana_default_admin_user }}"


### PR DESCRIPTION
Because grafana is running behind a reverse proxy, it will in some cases (e.g. in notifications) show links to localhost:3000 instead the web interface address.

This PR fixes that.